### PR TITLE
add validations for ApiStatus model

### DIFF
--- a/app/models/api_status.rb
+++ b/app/models/api_status.rb
@@ -1,2 +1,4 @@
 class ApiStatus < ApplicationRecord
+  validates :name, :url, presence: true
+  validates :is_deprecated, :has_sunset, inclusion: [true, false]
 end


### PR DESCRIPTION
Originally I had   `validates :name, :url, :is_deprecated, :has_sunset, presence: true` but it didn't like that, so the validation of inclusion for the boolean values to be `true` or `false`, should solve that problem. 

I also left out the method about the `:sunset_date` as it will save as `nil` if none is given and `:has_sunset` is `false` anyway


![image](https://user-images.githubusercontent.com/26676054/111877823-fd269600-899c-11eb-8d27-b05289024b6b.png)

